### PR TITLE
Various improvements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,12 @@ class dnsdist (
 {
 
   if ($use_upstream_package_source) {
+
+    apt::pin { 'dnsdist':
+      origin   => 'repo.powerdns.com',
+      priority => '600',
+    }
+
     apt::key { 'powerdns':
       ensure => present,
       id     => '9FAAA5577E8FCF62093D036C1B0C6205FD380FBB',
@@ -58,11 +64,6 @@ class dnsdist (
       release      => "${::lsbdistcodename}-dnsdist-${version}",
       architecture => 'amd64',
       require      => [Apt::Key['powerdns'], Apt::Pin['dnsdist']],
-    }
-
-    apt::pin { 'dnsdist':
-      origin   => 'repo.powerdns.com',
-      priority => '600',
     }
 
     Apt::Source['repo.powerdns.com'] ~> Class['apt::update'] -> Package['dnsdist']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,34 +29,48 @@ class dnsdist (
   $version          = $dnsdist::params::version,
   $webserver        = $dnsdist::params::webserver,
   $webserver_pass   = $dnsdist::params::webserver_pass,
+  $webserver_acl    = "127.0.0.1",
+  $api_key          = $dnsdist::params::api_key,
   $control_socket   = $dnsdist::params::control_socket,
+  $control_socket_key = $dnsdist::params::control_socket_key,
   $listen_addresess = $dnsdist::params::listen_addresess,
   $cache_enabled    = $dnsdist::params::cache_enabled,
   $cache_size       = $dnsdist::params::cache_size,
   $metrics_enabled  = $dnsdist::params::metrics_enabled,
   $metrics_host     = $dnsdist::params::metrics_host,
+  $os               = $dnsdist::params::os,
+  $use_upstream_package_source = $dnsdist::params::use_upstream_package_source,
   ) inherits dnsdist::params
 {
-  apt::pin { 'dnsdist':
-    origin   => 'repo.powerdns.com',
-    priority => '600',
-  }
 
-  apt::source { 'repo.powerdns.com':
-    location      => 'http://repo.powerdns.com/ubuntu',
-    repos         => 'main',
-    release       => join([$::lsbdistcodename, '-dnsdist-', $version], ''),
-    architecture  => 'amd64',
-    key           => {
+  if ($use_upstream_package_source) {
+    apt::key { 'powerdns':
+      ensure => present,
       id     => '9FAAA5577E8FCF62093D036C1B0C6205FD380FBB',
-      server => 'keyserver.ubuntu.com',
-    },
-    require       => [Apt::Pin['dnsdist']];
+      source => 'https://repo.powerdns.com/FD380FBB-pub.asc',
+      server => 'keyserver.ubuntu.com'
+    }
+
+    apt::source { 'repo.powerdns.com':
+      ensure       => present,
+      location     => "http://repo.powerdns.com/${os}",
+      repos        => 'main',
+      release      => "${::lsbdistcodename}-dnsdist-${version}",
+      architecture => 'amd64',
+      require      => [Apt::Key['powerdns'], Apt::Pin['dnsdist']],
+    }
+
+    apt::pin { 'dnsdist':
+      origin   => 'repo.powerdns.com',
+      priority => '600',
+    }
+
+    Apt::Source['repo.powerdns.com'] ~> Class['apt::update'] -> Package['dnsdist']
   }
 
   package { 'dnsdist':
     ensure  => present,
-    require => [Apt::Source['repo.powerdns.com']];
+    provider => 'apt',
   }
 
   concat { '/etc/dnsdist/dnsdist.conf' :

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,10 +5,14 @@ class dnsdist::params {
   $version          = '13'
   $webserver        = '0.0.0.0:80'
   $webserver_pass   = 'geheim'
+  $api_key          = undef
   $control_socket   = '127.0.0.1'
-  $listen_addresess = '0.0.0.0'
+  $control_socket_key  = undef
+  $listen_addresess = ['0.0.0.0']
   $cache_enabled    = false
   $cache_size       = 10000
   $metrics_enabled  = false
   $metrics_host     = '127.0.0.1'
+  $os               = downcase($facts['os']['name'])
+  $use_upstream_package_source = true
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,16 @@
       "operatingsystemrelease": [
         "14.04",
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9",
+        "10",
+        "11"
       ]
     }
   ],

--- a/templates/dnsdist.conf-header.erb
+++ b/templates/dnsdist.conf-header.erb
@@ -1,10 +1,18 @@
+setSecurityPollSuffix("")
 webserver("<%= @webserver %>", "<%= @webserver_pass %>")
+setWebserverConfig({acl="<%= @webserver_acl %>"})
+<%if @api_key %>
+  setWebserverConfig({apiKey="<%= @api_key %>"})
+<%end %>
 controlSocket("<%= @control_socket %>")
+<%if @control_socket_key %>
+setKey("<%= @control_socket_key %>")
+<%end %>
 <% @listen_addresess.each do |listen_addres| 
   -%>addLocal("<%= listen_addres %>")
 <% end -%>
 <% if @cache_enabled %>
-pc = newPacketCache(<%= @cache_size %>, 86400, 0, 60, 60)
+pc = newPacketCache(<%= @cache_size %>, {maxTTL=86400, minTTL=0, temporaryFailureTTL=60, staleTTL=60, dontAge=false})
 getPool(""):setCache(pc)
 <% end -%>
 <% if @metrics_enabled %>


### PR DESCRIPTION
- debian support
- allow distribution or upstream package
- add api and control keys
- add webserver acl

Tested and works with latest version of dnsdist 1.6.1